### PR TITLE
Added keybind to toggle the mod

### DIFF
--- a/src/client/java/org/kr1v/unlockedcamera/client/UnlockedCameraClient.java
+++ b/src/client/java/org/kr1v/unlockedcamera/client/UnlockedCameraClient.java
@@ -6,5 +6,7 @@ public class UnlockedCameraClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         UnlockedCameraConfigManager.initializeConfig();
+
+        UnlockedCameraKeybindManager.initializeKeybind();
     }
 }

--- a/src/client/java/org/kr1v/unlockedcamera/client/UnlockedCameraKeybindManager.java
+++ b/src/client/java/org/kr1v/unlockedcamera/client/UnlockedCameraKeybindManager.java
@@ -1,0 +1,27 @@
+package org.kr1v.unlockedcamera.client;
+
+import org.lwjgl.glfw.GLFW;
+
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
+
+public class UnlockedCameraKeybindManager {
+    private static KeyBinding toggleCameraUnlockedKey;
+
+    public static void initializeKeybind() {
+        toggleCameraUnlockedKey = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+                    "unlockedcamera.toggleCameraUnlockedKey",
+                    InputUtil.Type.KEYSYM,
+                    GLFW.GLFW_KEY_UNKNOWN,
+                    "unlockedcamera.key"
+        ));
+
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (toggleCameraUnlockedKey.wasPressed()) {
+                UnlockedCameraConfigManager.getConfig().enabled = !UnlockedCameraConfigManager.getConfig().enabled;
+            }
+        });
+    }
+}

--- a/src/main/resources/assets/unlockedcamera/lang/en_us.json
+++ b/src/main/resources/assets/unlockedcamera/lang/en_us.json
@@ -8,5 +8,7 @@
 	"unlockedcamera.shouldInvertMovementSwimming": "Invert movement swimming",
 	"unlockedcamera.shouldInvertMovementSwimming.description": "When looking upside down and swimming, will invert movement. Is recommended, very intuitive",
 	"unlockedcamera.shouldInvertMouse": "Invert mouse",
-	"unlockedcamera.shouldInvertMouse.description": "When looking upside down, will invert horizontal mouse movement. Is recommended, very intuitive"
+	"unlockedcamera.shouldInvertMouse.description": "When looking upside down, will invert horizontal mouse movement. Is recommended, very intuitive",
+    "unlockedcamera.toggleCameraUnlockedKey": "Key that toggles whether the mod is enabled",
+    "unlockedcamera.key": "A keybind created by the mod"
 }


### PR DESCRIPTION
Hello!
I noticed this functionality was missing so I figured I'd add it. I added an additional class with a static method that registers a keybind that toggles the "enabled" config setting the same way the modmenu screen does it.  The method is then called when the client is initialized in Unlocked. I also added the translations for the key category and the keybind itself so those should be registered.
I tried to follow your conventions but feel free to make any changes you wish. Thank you for your consideration!